### PR TITLE
fix: resolve iOS PWA message input padding

### DIFF
--- a/client/app/src/routes/remote/message-conversation.tsx
+++ b/client/app/src/routes/remote/message-conversation.tsx
@@ -31,10 +31,7 @@ const MessageContent = styled(Content)`
 const ContentWrapper = styled.div<{ $keyboardHeight: number }>`
   display: flex;
   flex-direction: column;
-  height: calc(
-    100dvh - 5rem - env(safe-area-inset-top) - env(safe-area-inset-bottom) -
-      ${({ $keyboardHeight }) => $keyboardHeight}px
-  );
+  height: calc(100dvh - 5rem - env(safe-area-inset-top) - ${({ $keyboardHeight }) => $keyboardHeight}px);
   overflow: hidden;
   transition: height 0.1s ease-out;
 `;

--- a/client/app/src/routes/remote/message-conversation.tsx
+++ b/client/app/src/routes/remote/message-conversation.tsx
@@ -134,14 +134,6 @@ const SendButton = styled(Button)`
   align-self: stretch;
 `;
 
-const Description = styled.p`
-  line-height: 1.25rem;
-  padding: 1rem 1.2rem;
-  border-radius: 1rem;
-  background-color: #aa0425;
-  margin-bottom: ${({ theme }) => theme.spacing.padding.l};
-`;
-
 const EmptyState = styled.div`
   text-align: center;
   padding: ${({ theme }) => theme.spacing.padding.xl};
@@ -266,8 +258,6 @@ export const MessageConversation = ({ direction }: MessageConversationProps) => 
         ) : (
           <ContentWrapper $keyboardHeight={keyboardHeight}>
             <ScrollableContent>
-              <Description>Send anonymous messages, keeping the magic of Secret Santa alive.</Description>
-
               <MessagesContainer>
                 {messages.length === 0 ? (
                   <EmptyState>No messages yet. Start the conversation!</EmptyState>


### PR DESCRIPTION
## Summary
- Fix excessive bottom padding in message conversation on iOS PWA by removing duplicate `safe-area-inset-bottom` calculation
- Remove descriptive text banner to declutter messaging interface

## Changes
1. Removed redundant `env(safe-area-inset-bottom)` from `ContentWrapper` height (handled by `InputContainer` padding)
2. Removed "Send anonymous messages" description text and its styled component

The `InputContainer` already accounts for the safe area inset with its padding-bottom, so subtracting it again from the container height caused double compensation on iOS devices with home indicators.